### PR TITLE
chore: update org.postgresql:postgresql vulnerable to SQL Injection v…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>[42.6.1,)</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request includes a small change to the `pom.xml` file. The change specifies a version range for the PostgreSQL dependency to ensure compatibility with versions starting from `42.6.1`