### PR TITLE
feat: Docker publish realese conf

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,13 +10,20 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [published]
+    workflow_dispatch:
+
+    release:
+        types: [published]
+
+
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    environment:
+      name: dockerhub
+      url: https://hub.docker.com/repository/docker/hahg/tmp-api-rest-spring-boot/
     permissions:
       packages: write
       contents: read
@@ -27,20 +34,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
+      # este sstep crea las etiquetas y metadatos para la imagen de Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+            images: |
+                hahg/tmp-api-rest-spring-boot
+            tags: |
+                type=ref,event=branch
+                type=ref,event=pr
+                type=semver,pattern={{version}}
+                type=semver,pattern={{major}}.{{minor}}
+                type=sha
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -4,9 +4,9 @@
 # Uso: ./build-and-push.sh [username] [tag]
 
 # Variables
-USERNAME=${1:-"tenpo"}
+USERNAME=${1:-"hahg"}
 TAG=${2:-"latest"}
-IMAGE_NAME="tenpo-challenge"
+IMAGE_NAME="tmp-api-rest-spring-boot"
 FULL_IMAGE_NAME="$USERNAME/$IMAGE_NAME:$TAG"
 
 echo "Construyendo la imagen Docker: $FULL_IMAGE_NAME"


### PR DESCRIPTION
This pull request updates the Docker workflow and the `build-and-push.sh` script to modernize dependencies, improve tagging, and align naming conventions. The key changes include updating Docker action versions, introducing new tagging strategies, and modifying default values in the shell script.

### Updates to Docker workflow (`.github/workflows/docker.yml`):

* Added `workflow_dispatch` to enable manual triggering of the workflow and defined an environment with a Docker Hub URL for better integration.
* Upgraded Docker actions to their latest stable versions (`docker/login-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v6`) and replaced `DOCKER_PASSWORD` with `DOCKERHUB_TOKEN` for improved security.
* Enhanced Docker metadata extraction by introducing a detailed tagging strategy, including branch, PR, semantic versioning, and commit SHA-based tags.

### Updates to `build-and-push.sh` script:

* Changed the default Docker username from `tenpo` to `hahg` and updated the default image name to `tmp-api-rest-spring-boot` for consistency with the repository's naming conventions.