### PR TITLE
chore: Docker publish realese conf

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
+          subject-name: index.docker.io/hahg/tmp-api-rest-spring-boot
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request updates the `subject-name` parameter in the `.github/workflows/docker.yml` file to reflect a new Docker Hub repository.

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L69-R69): Changed the `subject-name` from `index.docker.io/my-docker-hub-namespace/my-docker-hub-repository` to `index.docker.io/hahg/tmp-api-rest-spring-boot` in the `Generate artifact attestation` step.