### PR TITLE
feat: gha test workflow added

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,15 @@ name: Java CI with Maven
 on:
     push:
         branches:
-            - main # O la rama principal de tu repositorio
-            - 'refs/tags/*' # Para ejecutar en cada tag
-            - feature/* # Para ejecutar en cada rama de características
-            - chore/* # Para ejecutar en cada rama de mantenimiento
-            - bugfix/* # Para ejecutar en cada rama de corrección de errores
-            - hotfix/* # Para ejecutar en cada rama de corrección urgente
+            - main # Or the main branch of your repository
+            - 'refs/tags/*' # To run on each tag
+            - feature/* # To run on each feature branch
+            - chore/* # To run on each maintenance branch
+            - bugfix/* # To run on each bugfix branch
+            - hotfix/* # To run on each hotfix branch
 
     pull_request:
-        branches: [ main ] # O la rama principal de tu repositorio
+        branches: [ main ] # Or the main branch of your repository
 
 jobs:
     test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Java CI with Maven
+
+on:
+    push:
+    branches:
+        - main # O la rama principal de tu repositorio
+        - 'refs/tags/*' # Para ejecutar en cada tag
+        - feature/* # Para ejecutar en cada rama de características
+        - chore/* # Para ejecutar en cada rama de mantenimiento
+        - bugfix/* # Para ejecutar en cada rama de corrección de errores
+        - hotfix/* # Para ejecutar en cada rama de corrección urgente
+
+        pull_request:
+        branches: [ main ] # O la rama principal de tu repositorio
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v4
+        - name: Set up JDK 21 # Ajusta la versión de Java si es necesario
+            uses: actions/setup-java@v4
+            with:
+                java-version: '21'
+                distribution: 'temurin'
+                cache: maven
+                cache-dependency-path: 'pom.xml'
+
+        - name: Run tests
+            run: |
+                mvn test -Dnet.bytebuddy.experimental=true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,15 @@ name: Java CI with Maven
 
 on:
     push:
-    branches:
-        - main # O la rama principal de tu repositorio
-        - 'refs/tags/*' # Para ejecutar en cada tag
-        - feature/* # Para ejecutar en cada rama de características
-        - chore/* # Para ejecutar en cada rama de mantenimiento
-        - bugfix/* # Para ejecutar en cada rama de corrección de errores
-        - hotfix/* # Para ejecutar en cada rama de corrección urgente
+        branches:
+            - main # O la rama principal de tu repositorio
+            - 'refs/tags/*' # Para ejecutar en cada tag
+            - feature/* # Para ejecutar en cada rama de características
+            - chore/* # Para ejecutar en cada rama de mantenimiento
+            - bugfix/* # Para ejecutar en cada rama de corrección de errores
+            - hotfix/* # Para ejecutar en cada rama de corrección urgente
 
-        pull_request:
+    pull_request:
         branches: [ main ] # O la rama principal de tu repositorio
 
 jobs:
@@ -19,15 +19,16 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
-        - name: Set up JDK 21 # Ajusta la versión de Java si es necesario
-            uses: actions/setup-java@v4
-            with:
-                java-version: '21'
-                distribution: 'temurin'
-                cache: maven
-                cache-dependency-path: 'pom.xml'
 
-        - name: Run tests
-            run: |
-                mvn test -Dnet.bytebuddy.experimental=true
+        - name: Set up JDK 21 # Ajusta la versión de Java si es necesario
+          uses: actions/setup-java@v4
+          with:
+              java-version: '21'
+              distribution: 'temurin'
+              cache: maven
+              cache-dependency-path: 'pom.xml'
+
+        - name: Run test
+          run: |
+            mvn test -Dnet.bytebuddy.experimental=true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+            id-token: write
+            attestations: write
 
         steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enable continuous integration (CI) for a Java project using Maven. The workflow is designed to run tests automatically on various branches and tags.

### CI Workflow Addition:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R34): Added a new workflow named "Java CI with Maven" to run tests on the `main` branch, tags, and branches following specific naming patterns (`feature/*`, `chore/*`, `bugfix/*`, `hotfix/*`). It uses `ubuntu-latest` as the runner, sets up JDK 21 with Temurin distribution, and caches Maven dependencies. The workflow executes `mvn test` with an experimental Byte Buddy flag.